### PR TITLE
Use Public Boojum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ derivative = "2"
 
 franklin_crypto = {package = "franklin-crypto", features = ["plonk"], git = "https://github.com/matter-labs/franklin-crypto", branch = "snark_wrapper"}
 # franklin_crypto = {package = "franklin-crypto", features = ["plonk"], path = "../franklin-crypto"}
-boojum = {git = "https://github.com/matter-labs/boojum.git", branch = "main"}
+boojum = {git = "https://github.com/matter-labs/era-boojum.git", branch = "main"}
 # boojum = { path = "../boojum" }
 num-bigint = "0.3"
 num-integer = "0.1"


### PR DESCRIPTION
### What

This PR moves the repo to use the public version of boojum as it's being fully open sourced.